### PR TITLE
添加result封装上级接口,用于统一返回不用interface,导致的无法进行其他ADD操作

### DIFF
--- a/tool/result/result_map.go
+++ b/tool/result/result_map.go
@@ -39,3 +39,13 @@ func (c ResultMap) String() string {
 	}
 	return string(b)
 }
+
+// 接口封装, 替换返回interface, 出现无法add操作问题
+type Resultable interface {
+
+	// 添加额外字段
+	Add(key string, value interface{}) (rmp ResultMap)
+
+	// 直接添加结构体
+	AddStruct(value interface{}) (rmp ResultMap)
+}


### PR DESCRIPTION
result返回结果缺少统一的封装,操作不方便.